### PR TITLE
Check for zero variance predictions

### DIFF
--- a/Docker/sc1_utils.py
+++ b/Docker/sc1_utils.py
@@ -18,6 +18,11 @@ def setsAreEqual(l1, l2):
   return all([e1 == e2 for e1, e2 in zip(sorted(l1), sorted(l2))])
 
 
+def almostZero(val, tol=1e-9):
+  """Returns true if val is almost equal to zero."""
+  return abs(val) < tol
+
+
 def validateSC1(submission_path, goldstandard_path):
   """Validate the format of SC1 submission file given the golden file.
 
@@ -99,9 +104,14 @@ def scoreSC1(submission_path, goldstandard_path):
   pearsons = []
   for inhibitor in joined.index.get_level_values('inhibitor').unique():
     subset = joined.loc[inhibitor]
-    spearmans.append(
-        subset.corr(method='spearman').auc_submission.auc_goldstandard)
-    pearsons.append(
-        subset.corr(method='pearson').auc_submission.auc_goldstandard)
+    # If the predictions are constant, return zero for spearman correlation.
+    if almostZero(subset.auc_submission.var()):
+      spear = 0.0
+      pear = 0.0
+    else:
+      spear = subset.corr(method='spearman').auc_submission.auc_goldstandard
+      pear = subset.corr(method='pearson').auc_submission.auc_goldstandard
+    spearmans.append(spear)
+    pearsons.append(pear)
 
   return (numpy.mean(spearmans), numpy.mean(pearsons))

--- a/Docker/test/test_sc1.py
+++ b/Docker/test/test_sc1.py
@@ -107,4 +107,15 @@ class Subchallenge1Test(unittest.TestCase):
     self.submission_df = self.submission_df[['inhibitor', 'lab_id', 'auc']]
     self.assertEqual(self.runScoring(), (1.0, 1.0))
 
-
+  def testScoreWithConstantPrediction(self):
+    self.submission_df = pandas.DataFrame({
+      'lab_id': [str(v) for v in range(5)],
+      'inhibitor': ['inhibitor'] * 5,
+      'auc': [1.0] * 5,
+    })
+    self.golden_df = pandas.DataFrame({
+      'lab_id': [str(v) for v in range(5)],
+      'inhibitor': ['inhibitor'] * 5,
+      'auc': range(5),
+    })
+    self.assertEqual(self.runScoring(), (0.0, 0.0))


### PR DESCRIPTION
This new test reproduces the bug (it fails before the code change, and doesn't fail after).

I looked over the nan-producing submission, and a few drugs were producing a constant prediction for every specimen. I think that a spearman correlation of zero is a good way to handle those cases.